### PR TITLE
Added pdfx_plugin.dart into exports list

### DIFF
--- a/packages/pdfx/lib/pdfx.dart
+++ b/packages/pdfx/lib/pdfx.dart
@@ -1,6 +1,7 @@
 export 'src/renderer/has_pdf_support.dart';
 export 'src/renderer/interfaces/document.dart';
 export 'src/renderer/interfaces/page.dart';
+export '/src/renderer/web/pdfx_plugin.dart';
 export 'src/renderer/rgba_data.dart';
 
 export 'package:photo_view/photo_view.dart';


### PR DESCRIPTION
When the command `flutter pub get` is executed, the resulting file `generated_plugin_registrant.dart` generates an incorrect import with the following warning `Don't import implementation files from another package`. This would be resolved.