### PR TITLE
swap jcenter for mavenCentral

### DIFF
--- a/packages/pdfx/android/build.gradle
+++ b/packages/pdfx/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
Using `mavenCentral` instead of `jcenter` in `repositories` to remove the dependency on `jcenter` which often has downtime. 

Only did this for `pdfx` but can do this for others if desired.