### PR TITLE
pdfx - Update photo_view dependency to 0.14.0

### DIFF
--- a/packages/pdfx/CHANGELOG.md
+++ b/packages/pdfx/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1+3
+
+* Update photo_view dependency to 0.14.0
+
 ## 2.0.1+2
 
 * Fixed broken links at pub.dev

--- a/packages/pdfx/example/pubspec.yaml
+++ b/packages/pdfx/example/pubspec.yaml
@@ -22,10 +22,6 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^1.0.4
 
-dependency_overrides:
-  photo_view:
-    git: https://github.com/bluefireteam/photo_view
-
 flutter:
   uses-material-design: true
 

--- a/packages/pdfx/pubspec.yaml
+++ b/packages/pdfx/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdfx
 description: Flutter plugin to render & show PDF pages as images on Web, MacOS, Windows, Android and iOS.
 repository: https://github.com/ScerIO/packages.flutter/tree/master/packages/pdfx
 issue_tracker: https://github.com/ScerIO/packages.flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pdfx%22
-version: 2.0.1+2
+version: 2.0.1+3
 
 environment:
   sdk: ">=2.16.2 <3.0.0"
@@ -20,7 +20,7 @@ dependencies:
   extension: ^0.4.0
   synchronized: ^3.0.0
   universal_platform: ^1.0.0+1
-  photo_view: ^0.13.0
+  photo_view: ^0.14.0
   vector_math: ^2.1.01
 
 dev_dependencies:


### PR DESCRIPTION
The example was already overriding this dependency to point to master which is 0.14.0.  I'm using another package flutter_quill which also depends on photo_view and was recently updated to 0.14.0.

There are no breaking changes between 0.13.0 and 0.14.0 of photo_view