### PR TITLE
Fix render `format` example in README

### DIFF
--- a/packages/pdfx/README.md
+++ b/packages/pdfx/README.md
@@ -154,7 +154,7 @@ PdfView(
   renderer: (PdfPage page) => page.render(
     width: page.width * 2,
     height: page.height * 2,
-    format: PdfPageFormat.JPEG,
+    format: PdfPageImageFormat.jpeg,
     backgroundColor: '#FFFFFF',
   ),
 );


### PR DESCRIPTION
Seems that the local type had been renamed, but the README was not yet adapted.