### PR TITLE
[epub-view] add optional shrinkWrap parameter to ScrollablePositionedList.builder

### DIFF
--- a/packages/epub_view/lib/src/ui/epub_view.dart
+++ b/packages/epub_view/lib/src/ui/epub_view.dart
@@ -31,12 +31,13 @@ class EpubView extends StatefulWidget {
     this.builders = const EpubViewBuilders<DefaultBuilderOptions>(
       options: DefaultBuilderOptions(),
     ),
+    this.shrinkWrap = false,
     Key? key,
   }) : super(key: key);
 
   final EpubController controller;
   final ExternalLinkPressed? onExternalLinkPressed;
-
+  final bool shrinkWrap;
   final void Function(EpubChapterViewValue? value)? onChapterChanged;
 
   /// Called when a document is loaded
@@ -366,6 +367,7 @@ class _EpubViewState extends State<EpubView> {
 
   Widget _buildLoaded(BuildContext context) {
     return ScrollablePositionedList.builder(
+      shrinkWrap: widget.shrinkWrap,
       initialScrollIndex: _epubCfiReader!.paragraphIndexByCfiFragment ?? 0,
       itemCount: _paragraphs.length,
       itemScrollController: _itemScrollController,


### PR DESCRIPTION
This pr is adding an optional `shrinkWrap` parameter to `ScrollablePositionedList.builder`;

**Motivation.**

I'm using `Epub` inside `CustomScrollView`, which has its own scroll. The current version of epub viewer, doesn't have shrinkWrap parameter inside the  ScrollablePositionedList.builder. Wich gives ScrollablePositionedList  expand to the maximum allowed height. CustomScrollView has unbounded constraints. That gives me  `Vertical viewport was given unbounded height.` exception.


**Change**

- Added optional named `shrinkWrap` parameter to `EpubView` with `false` default value;
