### PR TITLE
[pdfx] fix: make it iOS 13 compatible

### DIFF
--- a/packages/pdfx/ios/Classes/Hooks.swift
+++ b/packages/pdfx/ios/Classes/Hooks.swift
@@ -5,9 +5,9 @@ import Foundation
 extension UIColor {
     convenience init(hexString: String) {
         let hex = hexString.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
-        var int = UInt32()
-        Scanner(string: hex).scanHexInt32(&int)
-        let a, r, g, b: UInt32
+        var int = UInt64()
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
         switch hex.count {
         case 3: // RGB (12-bit)
             (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)


### PR DESCRIPTION
UInt32 is deprecated on iOS 13.