### PR TITLE
Updated pubspec.yaml and device_info_plus

### DIFF
--- a/packages/pdfx/pubspec.yaml
+++ b/packages/pdfx/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   plugin_platform_interface: ^2.1.2
   js: ^0.6.4
-  device_info_plus: ^5.0.0
+  device_info_plus: ^7.0.0
   uuid: ^3.0.6
   meta: ^1.7.0
   extension: ^0.5.0


### PR DESCRIPTION
Hey guys,

could you use the newer version of device_info_plus? Checking it locally with pub outdated showed no errors.

Best wishes