### PR TITLE
replace assert with return in `_loadDocument()`

### DIFF
--- a/packages/pdfx/lib/src/viewer/simple/pdf_controller.dart
+++ b/packages/pdfx/lib/src/viewer/simple/pdf_controller.dart
@@ -102,7 +102,7 @@ class PdfController with BasePdfController {
     Future<PdfDocument> documentFuture, {
     int initialPage = 1,
   }) async {
-    assert(_pdfViewState != null);
+    if (_pdfViewState == null) return;
 
     if (!await hasPdfSupport()) {
       _pdfViewState!._loadingError = Exception(


### PR DESCRIPTION
Hi, I recently came across an error of which the stack trace is attached below

package name: pdfx
package version: 2.2.0

```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: [11:25:42]Null check operator used on a null value. Error thrown null.
       at PdfController._loadDocument(pdf_controller.dart:125)
```

For solution, I purpose to remove the assert statement in the beginning of `_loadDocument()` since it is only executed in debug mode, and replace it with a normal null reference check.


flutter doctor result:
```
Doctor summary (to see all details, run flutter doctor -v):
[!] Flutter (Channel stable, 3.7.5, on macOS 12.6 21G115 darwin-arm64, locale
    en)
    ! Warning: `flutter` on your path resolves to
      /Users/jiaqifung/Dev/flutter/bin/flutter, which is not inside your current
      Flutter SDK checkout at /Users/jiaqifung/dev/flutter. Consider adding
      /Users/jiaqifung/dev/flutter/bin to the front of your path.
    ! Warning: `dart` on your path resolves to
      /opt/homebrew/Cellar/dart/2.16.1/libexec/bin/dart, which is not inside
      your current Flutter SDK checkout at /Users/jiaqifung/dev/flutter.
      Consider adding /Users/jiaqifung/dev/flutter/bin to the front of your
      path.
[!] Android toolchain - develop for Android devices (Android SDK version
    33.0.0-rc3)
    ✗ cmdline-tools component is missing
      Run `path/to/sdkmanager --install "cmdline-tools;latest"`
      See https://developer.android.com/studio/command-line for more details.
    ✗ Android license status unknown.
      Run `flutter doctor --android-licenses` to accept the SDK licenses.
      See https://flutter.dev/docs/get-started/install/macos#android-setup for
      more details.
[✓] Xcode - develop for iOS and macOS (Xcode 14.2)
[✓] Chrome - develop for the web
[✓] Android Studio (version 2021.2)
[✓] VS Code (version 1.75.1)
[✓] Connected device (3 available)
[✓] HTTP Host Availability

! Doctor found issues in 2 categories.
➜  ~ 
```