### PR TITLE
Move pdf support check from viewer to renderer

### DIFF
--- a/packages/pdfx/lib/src/renderer/has_pdf_support.dart
+++ b/packages/pdfx/lib/src/renderer/has_pdf_support.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:universal_platform/universal_platform.dart';
 
+final _deviceInfo = DeviceInfoPlugin();
+
 Future<bool> hasPdfSupport() async {
   if (UniversalPlatform.isMacOS ||
       UniversalPlatform.isIOS ||
@@ -11,8 +13,7 @@ Future<bool> hasPdfSupport() async {
     return true;
   }
   if (UniversalPlatform.isAndroid) {
-    final deviceInfo = DeviceInfoPlugin();
-    final androidInfo = await deviceInfo.androidInfo;
+    final androidInfo = await _deviceInfo.androidInfo;
     return androidInfo.version.sdkInt! >= 21;
   }
   return false;

--- a/packages/pdfx/lib/src/renderer/interfaces/document.dart
+++ b/packages/pdfx/lib/src/renderer/interfaces/document.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 
+import 'package:pdfx/src/renderer/has_pdf_support.dart';
 import 'package:pdfx/src/renderer/interfaces/platform.dart';
 
 import 'page.dart';
@@ -34,19 +35,25 @@ abstract class PdfDocument {
   /// For Web, [filePath] can be relative path from `index.html` or any
   /// arbitrary URL but it may be restricted by CORS.
   /// `password supported only for web!`
-  static Future<PdfDocument> openFile(String filePath, {String? password}) =>
-      PdfxPlatform.instance.openFile(filePath, password: password);
+  static Future<PdfDocument> openFile(String filePath, {String? password}) {
+    assertHasPdfSupport();
+    return PdfxPlatform.instance.openFile(filePath, password: password);
+  }
 
   /// Opening the specified asset.
   /// `password supported only for web!`
-  static Future<PdfDocument> openAsset(String name, {String? password}) =>
-      PdfxPlatform.instance.openAsset(name, password: password);
+  static Future<PdfDocument> openAsset(String name, {String? password}) {
+    assertHasPdfSupport();
+    return PdfxPlatform.instance.openAsset(name, password: password);
+  }
 
   /// Opening the PDF on memory.
   /// `password supported only for web!`
   static Future<PdfDocument> openData(FutureOr<Uint8List> data,
-          {String? password}) =>
-      PdfxPlatform.instance.openData(data, password: password);
+      {String? password}) {
+    assertHasPdfSupport();
+    return PdfxPlatform.instance.openData(data, password: password);
+  }
 
   /// Get page object. The first page is 1.
   Future<PdfPage> getPage(
@@ -63,6 +70,10 @@ abstract class PdfDocument {
   @override
   String toString() =>
       '$runtimeType{document: $sourceName, id: $id, pagesCount: $pagesCount}';
+}
+
+Future<void> assertHasPdfSupport() async {
+  if (!await hasPdfSupport()) throw PlatformNotSupportedException();
 }
 
 class PdfDocumentAlreadyClosedException implements Exception {

--- a/packages/pdfx/lib/src/viewer/pinch/pdf_controller_pinch.dart
+++ b/packages/pdfx/lib/src/viewer/pinch/pdf_controller_pinch.dart
@@ -68,14 +68,6 @@ class PdfControllerPinch extends TransformationController
   }) async {
     assert(_state != null);
 
-    if (!await hasPdfSupport()) {
-      _state!._loadingError = Exception(
-          'This device does not support the display of PDF documents');
-
-      loadingState.value = PdfLoadingState.error;
-      return;
-    }
-
     try {
       _state?._releasePages();
 

--- a/packages/pdfx/lib/src/viewer/pinch/pdf_view_pinch.dart
+++ b/packages/pdfx/lib/src/viewer/pinch/pdf_view_pinch.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 
 import 'package:flutter/widgets.dart'
     hide InteractiveViewer, TransformationController;
-import 'package:pdfx/src/renderer/has_pdf_support.dart';
 import 'package:pdfx/src/renderer/interfaces/document.dart';
 import 'package:pdfx/src/renderer/interfaces/page.dart';
 import 'package:pdfx/src/viewer/base/base_pdf_builders.dart';

--- a/packages/pdfx/lib/src/viewer/simple/pdf_controller.dart
+++ b/packages/pdfx/lib/src/viewer/simple/pdf_controller.dart
@@ -34,7 +34,7 @@ class PdfController with BasePdfController {
 
   /// Actual showed page
   @override
-  int get page => (_pdfViewState!._currentIndex) + 1;
+  int get page => pageListenable.value;
 
   /// Count of all pages in document
   @override
@@ -104,20 +104,13 @@ class PdfController with BasePdfController {
   }) async {
     assert(_pdfViewState != null);
 
-    if (!await hasPdfSupport()) {
-      _pdfViewState!._loadingError = Exception(
-          'This device does not support the display of PDF documents');
-      loadingState.value = PdfLoadingState.error;
-      return;
-    }
-
     try {
       if (page != initialPage) {
         _pdfViewState?.widget.onPageChanged?.call(initialPage);
         pageListenable.value = initialPage;
       }
       _reInitPageController(initialPage);
-      _pdfViewState!._currentIndex = this.initialPage = initialPage;
+      this.initialPage = initialPage;
 
       _document = await documentFuture;
       loadingState.value = PdfLoadingState.success;

--- a/packages/pdfx/lib/src/viewer/simple/pdf_view.dart
+++ b/packages/pdfx/lib/src/viewer/simple/pdf_view.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/widgets.dart';
-import 'package:pdfx/src/renderer/has_pdf_support.dart';
 import 'package:pdfx/src/renderer/interfaces/document.dart';
 import 'package:pdfx/src/renderer/interfaces/page.dart';
 import 'package:pdfx/src/viewer/base/base_pdf_builders.dart';
@@ -80,13 +79,11 @@ class _PdfViewState extends State<PdfView> {
   final Map<int, PdfPageImage?> _pages = {};
   PdfController get _controller => widget.controller;
   Exception? _loadingError;
-  late int _currentIndex;
 
   @override
   void initState() {
     super.initState();
     _controller._attach(this);
-    _currentIndex = _controller._pageController!.initialPage;
     _controller.loadingState.addListener(() {
       switch (_controller.loadingState.value) {
         case PdfLoadingState.loading:
@@ -213,10 +210,9 @@ class _PdfViewState extends State<PdfView> {
         backgroundDecoration: widget.backgroundDecoration,
         pageController: _controller._pageController,
         onPageChanged: (index) {
-          _currentIndex = index;
           final pageNumber = index + 1;
-          widget.onPageChanged?.call(pageNumber);
           _controller.pageListenable.value = pageNumber;
+          widget.onPageChanged?.call(pageNumber);
         },
         scrollDirection: widget.scrollDirection,
         scrollPhysics: widget.physics,


### PR DESCRIPTION
We're currently not able to test pdfx viewer components in CI, as the viewer components assert that the current device has PDF support, and our CI is running linux. We've mocked out the pdf renderer, and we're supplying a MockPdfDocument to `PdfView`, which works fine on MacOS, but fails in CI. By moving the check to the renderer we can successfully test PdfView in CI.

I also removed `PdfViewState._currentIndex`. The main reason is because it was `late` inited, and removing the `await hasPdfSupport` check meant that it started being accessed before it was inited. It also had an off by one error on initialisation. Instead, we can just use the current value of the `pageListenable`.