### PR TITLE
Fixup rendering issues in chromium based web-browsers.

### DIFF
--- a/packages/pdfx/lib/src/renderer/web/document/page.dart
+++ b/packages/pdfx/lib/src/renderer/web/document/page.dart
@@ -38,8 +38,8 @@ class Page {
   }) async {
     final html.CanvasElement canvas =
         js.context['document'].createElement('canvas');
-    final html.CanvasRenderingContext2D context =
-        canvas.getContext('2d') as html.CanvasRenderingContext2D;
+    final html.CanvasRenderingContext2D context = canvas
+        .getContext('2d', {"alpha": false}) as html.CanvasRenderingContext2D;
 
     final viewport = renderer
         .getViewport(PdfjsViewportParams(scale: width / _viewport.width));

--- a/packages/pdfx/lib/src/renderer/web/platform.dart
+++ b/packages/pdfx/lib/src/renderer/web/platform.dart
@@ -241,8 +241,8 @@ class PdfPageImageWeb extends PdfPageImage {
     final preViewport = pdfJsPage.getViewport(PdfjsViewportParams(scale: 1));
     final html.CanvasElement canvas =
         js.context['document'].createElement('canvas');
-    final html.CanvasRenderingContext2D context =
-        canvas.getContext('2d') as html.CanvasRenderingContext2D;
+    final html.CanvasRenderingContext2D context = canvas
+        .getContext('2d', {"alpha": false}) as html.CanvasRenderingContext2D;
 
     final viewport = pdfJsPage
         .getViewport(PdfjsViewportParams(scale: width / preViewport.width));
@@ -441,8 +441,8 @@ class PdfPageTextureWeb extends PdfPageTexture {
       ..width = preWidth
       ..height = preHeight;
 
-    final html.CanvasRenderingContext2D context =
-        canvas.getContext('2d') as html.CanvasRenderingContext2D;
+    final html.CanvasRenderingContext2D context = canvas
+        .getContext('2d', {"alpha": false}) as html.CanvasRenderingContext2D;
 
     if (backgroundColor != null) {
       context


### PR DESCRIPTION
There were certain browser / system configurations that caused issues with pdf-rendering.
Those documents have lots of white patches / artifacts. This seems to only be observed in chrome based browers with Intel GPUs.
 See:
https://github.com/wojtekmaj/react-pdf/issues/1010
https://github.com/wojtekmaj/react-pdf/issues/1025#issuecomment-1373922046