### PR TITLE
Update visibility_detector

### DIFF
--- a/packages/auto_animated/pubspec.yaml
+++ b/packages/auto_animated/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  visibility_detector: ^0.3.3
+  visibility_detector: ^0.4.0+2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Update visibility_detector to 0.4.0+2

Error:
Because no versions of auto_animated match >3.1.0 <4.0.0 and auto_animated 3.1.0 depends on visibility_detector ^0.3.3, auto_animated ^3.1.0 requires visibility_detector ^0.3.3. And because flutter_chat_ui >=1.6.7 depends on visibility_detector ^0.4.0+2, auto_animated ^3.1.0 is incompatible with flutter_chat_ui >=1.6.7. So, because sellme depends on both flutter_chat_ui ^1.6.8 and auto_animated ^3.1.0, version solving failed. exit code 1