### PR TITLE
[epub_view] Fix cfi generation

### DIFF
--- a/packages/epub_view/lib/src/data/epub_cfi/_generator.dart
+++ b/packages/epub_view/lib/src/data/epub_cfi/_generator.dart
@@ -99,7 +99,7 @@ class EpubCfiGenerator {
         index = i;
         break;
       }
-      if (edRef!.contains(items[i].IdRef!)) {
+      if (items[i].IdRef!.contains(edRef!)) {
         partIndex = i;
       }
     }


### PR DESCRIPTION
Fix this problem.
https://github.com/ScerIO/packages.flutter/issues/361

It seems there is a problem with the `_fileNameAsChapterName` method or the `getIdRefIndex` method is using the wrong condition.

<img width="621" alt="image" src="https://github.com/ScerIO/packages.flutter/assets/9246532/91994ccc-7355-4eda-9b3b-b4e4e4cf8c2a">

