### PR TITLE
deprecated member 'DecoderCallback' fix

### DIFF
--- a/packages/pdfx/lib/src/viewer/pdf_page_image_provider.dart
+++ b/packages/pdfx/lib/src/viewer/pdf_page_image_provider.dart
@@ -1,8 +1,6 @@
-// ignore: unnecessary_import
 import 'dart:typed_data';
 import 'dart:ui' as ui show Codec;
 import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:pdfx/src/renderer/interfaces/page.dart';
 
@@ -21,9 +19,7 @@ class PdfPageImageProvider extends ImageProvider<PdfPageImageProvider> {
   final double scale;
 
   @override
-  ImageStreamCompleter loadImage(
-          PdfPageImageProvider key, ImageDecoderCallback decode) =>
-      MultiFrameImageStreamCompleter(
+  ImageStreamCompleter load(PdfPageImageProvider key, DecoderBufferCallback decode) => MultiFrameImageStreamCompleter(
         codec: _loadAsync(key, decode),
         scale: key.scale,
         informationCollector: () sync* {
@@ -36,19 +32,19 @@ class PdfPageImageProvider extends ImageProvider<PdfPageImageProvider> {
       SynchronousFuture<PdfPageImageProvider>(this);
 
   Future<ui.Codec> _loadAsync(
-    PdfPageImageProvider key,
-    ImageDecoderCallback decode,
-  ) async {
+      PdfPageImageProvider key,
+      DecoderBufferCallback decode) async {
     assert(key == this);
 
     final loadedPdfPageImage = await pdfPageImage;
     final Uint8List bytes = loadedPdfPageImage.bytes;
-    final ImmutableBuffer buffer = await ImmutableBuffer.fromUint8List(bytes);
 
     if (bytes.lengthInBytes == 0) {
       throw StateError('${loadedPdfPageImage.pageNumber} page '
           'cannot be loaded as an image.');
     }
+
+    final ImmutableBuffer buffer = await ImmutableBuffer.fromUint8List(bytes);
 
     return decode(buffer);
   }


### PR DESCRIPTION
Replaced deprecated 'DecoderCallback' with official replacement 'DecoderBufferCallback'