### PR TITLE
[pdfx] avoid resetting to initialPage each view

### DIFF
--- a/packages/pdfx/lib/src/viewer/simple/pdf_controller.dart
+++ b/packages/pdfx/lib/src/viewer/simple/pdf_controller.dart
@@ -136,7 +136,7 @@ class PdfController with BasePdfController {
 
     _pdfViewState = pdfViewState;
 
-    _reInitPageController(initialPage);
+    _reInitPageController(page);
 
     if (_document == null) {
       _loadDocument(document, initialPage: initialPage);


### PR DESCRIPTION

Thanks for the great library.

In my opinion, when a controller is attached to a view, the view state should be determined by the controller state.
In the current code, each time a controller is attached to a view, it is initialized with an initialPage.

This creates the problem that every time a controller on a page moved from initialPage is attached to a view, the page is initialized to initialPage.
This causes a problem in cases where the current controller is attached to another view, such as zooming in on an already open PDF overlay, which causes the page to revert from the currently open page to the initialPage.

Therefore, we modified the code so that when reInitController is executed, it initializes to the page held by the controller instead of initialPage.
[We are aware that PdfPinchController already has the same behavior.](https://github.com/ScerIO/packages.flutter/blob/2b0ea816a0f4e87bd46ccd419e2fd5800f7fdf0c/packages/pdfx/lib/src/viewer/pinch/pdf_controller_pinch.dart#L127-L133)

I would appreciate it if you could merge this as well, in terms of matching the behavior.