### PR TITLE
Upgrade version of pdfjs library

### DIFF
--- a/packages/pdfx/bin/install_web.dart
+++ b/packages/pdfx/bin/install_web.dart
@@ -1,38 +1,78 @@
-import 'dart:io';
+import "dart:io";
 
-const findString = '<body>';
+const String pdfjsVersion = "4.6.82";
 
-const _template = """$findString
+const String findString = "<body>";
+const String _template = """$findString
   <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/build/pdf.min.mjs" type="module"></script>
   <script type="module">
   var { pdfjsLib } = globalThis;
   pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/build/pdf.worker.mjs";
 
   var pdfRenderOptions = {
-    cMapUrl: 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/cmaps/',
+    cMapUrl: "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/cmaps/",
     cMapPacked: true,
   }
   </script>""";
 
 void main(List<String> args) async {
-  stdout.writeln('[Modify web/index.hml by addition pdfjs]');
+  stdout.writeln("[Modify web/index.hml by addition pdfjs]");
 
-  final htmlFile = File('web/index.html');
+  final htmlFile = File("web/index.html");
 
   if (!await htmlFile.exists()) {
-    stdout.writeln('Cannot find web/index.html');
+    stdout.writeln("Cannot find web/index.html");
     exit(1);
   }
 
-  final document = await htmlFile.readAsString();
+  final String document = await htmlFile.readAsString();
 
-  if (document.contains('pdfRenderOptions')) {
-    stdout.writeln('Already installed, operation aborted');
-    exit(2);
+  if (document.contains("pdfRenderOptions")) {
+    stdout.writeln("Already installed, checking version consistency");
+
+    final VersionConsistencyChecker checker = VersionConsistencyChecker(expectedVersion: "4.6.82");
+    if (checker.checkVersion(document)) {
+      stdout.writeln("Version is consistent");
+
+      exit(2);
+    } else {
+      stdout.writeln("Version is inconsistent, fixing version");
+      final resultDocument = checker.fixVersion(document);
+      await htmlFile.writeAsString(resultDocument);
+      stdout.writeln("Installation successful");
+
+      exit(0);
+    }
   }
 
   final resultDocument = document.replaceFirst(findString, _template);
   await htmlFile.writeAsString(resultDocument);
 
-  stdout.writeln('installation successfully');
+  stdout.writeln("installation successfully");
+}
+
+class VersionConsistencyChecker {
+  static final RegExp versionRegex = RegExp(r"pdfjs-dist@(\d+\.\d+\.\d+)");
+
+  final String expectedVersion;
+
+  VersionConsistencyChecker({required this.expectedVersion});
+
+  bool checkVersion(final String indexContent) {
+    if (versionRegex.hasMatch(indexContent)) {
+      final Iterable<RegExpMatch> matches = versionRegex.allMatches(indexContent);
+
+      for (final match in matches) {
+        if (match.group(1) != expectedVersion) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  String fixVersion(final String indexContent) {
+    return indexContent.replaceAll(versionRegex, "pdfjs-dist@$expectedVersion");
+  }
 }

--- a/packages/pdfx/bin/install_web.dart
+++ b/packages/pdfx/bin/install_web.dart
@@ -3,13 +3,15 @@ import 'dart:io';
 const findString = '<body>';
 
 const _template = """$findString
-  <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@2.12.313/build/pdf.js" type="text/javascript"></script>
-  <script type="text/javascript">
-    pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdn.jsdelivr.net/npm/pdfjs-dist@2.12.313/build/pdf.worker.min.js";
-    pdfRenderOptions = {
-      cMapUrl: 'https://cdn.jsdelivr.net/npm/pdfjs-dist@2.12.313/cmaps/',
-      cMapPacked: true,
-    }
+  <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/build/pdf.min.mjs" type="module"></script>
+  <script type="module">
+  var { pdfjsLib } = globalThis;
+  pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/build/pdf.worker.mjs";
+
+  var pdfRenderOptions = {
+    cMapUrl: 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/cmaps/',
+    cMapPacked: true,
+  }
   </script>""";
 
 void main(List<String> args) async {

--- a/packages/pdfx/example/lib/pinch.dart
+++ b/packages/pdfx/example/lib/pinch.dart
@@ -23,7 +23,7 @@ class _PinchPageState extends State<PinchPage> {
       // document: PdfDocument.openAsset('assets/hello.pdf'),
       document: PdfDocument.openData(
         InternetFile.get(
-          'https://www.aeee.in/wp-content/uploads/2020/08/Sample-pdf.pdf',
+          "https://cdn.filestackcontent.com/wcrjf9qPTCKXV3hMXDwK",
         ),
       ),
       initialPage: _initialPage,

--- a/packages/pdfx/example/web/index.html
+++ b/packages/pdfx/example/web/index.html
@@ -52,9 +52,7 @@
     cMapUrl: 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/cmaps/',
     cMapPacked: true,
   }
-
-  console.log("HELLOOO");
-  </script>
+</script>
 <script src="flutter_bootstrap.js" async></script>
 </body>
 

--- a/packages/pdfx/example/web/index.html
+++ b/packages/pdfx/example/web/index.html
@@ -42,11 +42,11 @@
 </head>
 
 <body>
-<script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/build/pdf.min.mjs"
+<script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/build/pdf.mjs"
         type="module"></script>
 <script type="module">
   var { pdfjsLib } = globalThis;
-  pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/build/pdf.worker.min.mjs";
+  pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/build/pdf.worker.mjs";
 
   var pdfRenderOptions = {
     cMapUrl: 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/cmaps/',

--- a/packages/pdfx/example/web/index.html
+++ b/packages/pdfx/example/web/index.html
@@ -22,7 +22,7 @@
   <meta name="description" content="A new Flutter project.">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="example">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
@@ -35,35 +35,27 @@
 
   <script>
     // The value below is injected by flutter build, do not touch.
-    var serviceWorkerVersion = null;
+    var serviceWorkerVersion = {{flutter_service_worker_version}};
   </script>
   <!-- This script adds the flutter initialization JS code -->
   <script src="flutter.js" defer></script>
 </head>
 
 <body>
-  <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@2.12.313/build/pdf.js" type="text/javascript"></script>
-  <script type="text/javascript">
-    pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdn.jsdelivr.net/npm/pdfjs-dist@2.12.313/build/pdf.worker.min.js";
-    pdfRenderOptions = {
-      cMapUrl: 'https://cdn.jsdelivr.net/npm/pdfjs-dist@2.12.313/cmaps/',
-      cMapPacked: true,
-    }
+<script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/build/pdf.min.mjs"
+        type="module"></script>
+<script type="module">
+  var { pdfjsLib } = globalThis;
+  pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/build/pdf.worker.min.mjs";
+
+  var pdfRenderOptions = {
+    cMapUrl: 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/cmaps/',
+    cMapPacked: true,
+  }
+
+  console.log("HELLOOO");
   </script>
-  <script>
-    window.addEventListener('load', function (ev) {
-      // Download main.dart.js
-      _flutter.loader.loadEntrypoint({
-        serviceWorker: {
-          serviceWorkerVersion: serviceWorkerVersion,
-        }
-      }).then(function (engineInitializer) {
-        return engineInitializer.initializeEngine();
-      }).then(function (appRunner) {
-        return appRunner.runApp();
-      });
-    });
-  </script>
+<script src="flutter_bootstrap.js" async></script>
 </body>
 
 </html>

--- a/packages/pdfx/lib/src/renderer/web/constants.dart
+++ b/packages/pdfx/lib/src/renderer/web/constants.dart
@@ -1,0 +1,8 @@
+import 'package:pdfx/src/renderer/web/pdfjs.dart';
+
+class Constants {
+  static const PdfjsRenderOptions defaultPdfjsRenderOptions = PdfjsRenderOptions.constant(
+    cMapUrl: 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/cmaps/',
+    cMapPacked: true,
+  );
+}

--- a/packages/pdfx/lib/src/renderer/web/constants.dart
+++ b/packages/pdfx/lib/src/renderer/web/constants.dart
@@ -1,7 +1,7 @@
 import 'package:pdfx/src/renderer/web/pdfjs.dart';
 
 class Constants {
-  static const PdfjsRenderOptions defaultPdfjsRenderOptions = PdfjsRenderOptions.constant(
+  static PdfjsRenderOptions defaultPdfjsRenderOptions = PdfjsRenderOptions.constant(
     cMapUrl: 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/cmaps/',
     cMapPacked: true,
   );

--- a/packages/pdfx/lib/src/renderer/web/pdfjs.dart
+++ b/packages/pdfx/lib/src/renderer/web/pdfjs.dart
@@ -30,7 +30,11 @@ bool checkPdfjsLibInstallation() => _pdfjsLib != null;
 @JS('pdfjsLib')
 external PdfjsLib? get _pdfjsLib;
 
-PdfjsRenderOptions get _pdfRenderOptions => Constants.defaultPdfjsRenderOptions;
+@JS("pdfRenderOptions")
+external PdfjsRenderOptions? get _pdfRenderOptionsFromContext;
+
+// Safe check
+PdfjsRenderOptions get _pdfRenderOptions => _pdfRenderOptionsFromContext ?? Constants.defaultPdfjsRenderOptions;
 
 extension type PdfjsLib(JSObject _) implements JSObject {
   external PdfjsDocumentTask getDocument(PdfjsRenderOptions options);
@@ -55,7 +59,7 @@ extension type PdfjsRenderOptions._(JSObject _) implements JSObject {
     String? password,
   });
 
-  external const factory PdfjsRenderOptions.constant({
+  external factory PdfjsRenderOptions.constant({
     String cMapUrl,
     bool cMapPacked,
   });

--- a/packages/pdfx/lib/src/renderer/web/pdfjs.dart
+++ b/packages/pdfx/lib/src/renderer/web/pdfjs.dart
@@ -22,6 +22,7 @@ library pdf.js;
 import 'dart:js_interop';
 import 'dart:typed_data';
 
+import 'package:pdfx/src/renderer/web/constants.dart';
 import 'package:web/web.dart' as web;
 
 bool checkPdfjsLibInstallation() => _pdfjsLib != null;
@@ -29,8 +30,7 @@ bool checkPdfjsLibInstallation() => _pdfjsLib != null;
 @JS('pdfjsLib')
 external PdfjsLib? get _pdfjsLib;
 
-@JS('pdfRenderOptions')
-external PdfjsRenderOptions get _pdfRenderOptions;
+PdfjsRenderOptions get _pdfRenderOptions => Constants.defaultPdfjsRenderOptions;
 
 extension type PdfjsLib(JSObject _) implements JSObject {
   external PdfjsDocumentTask getDocument(PdfjsRenderOptions options);
@@ -55,8 +55,12 @@ extension type PdfjsRenderOptions._(JSObject _) implements JSObject {
     String? password,
   });
 
-  external String get cMapUrl;
+  external const factory PdfjsRenderOptions.constant({
+    String cMapUrl,
+    bool cMapPacked,
+  });
 
+  external String get cMapUrl;
   external bool get cMapPacked;
 }
 

--- a/packages/pdfx/pubspec.yaml
+++ b/packages/pdfx/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdfx
 description: Flutter plugin to render & show PDF pages as images on Web, MacOS, Windows, Android and iOS.
 repository: https://github.com/ScerIO/packages.flutter/tree/main/packages/pdfx
 issue_tracker: https://github.com/ScerIO/packages.flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pdfx%22
-version: 2.7.0
+version: 2.7.1
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
This PR contains an update to the latest version of pdfjs library - which has been marked vulnerable for some CVEs in it's older version - and a refreshed install script for web that allows the upgrading of pdfjs library dinamically.