### PR TITLE
chore: updated device_info_plus version

### DIFF
--- a/packages/pdfx/pubspec.yaml
+++ b/packages/pdfx/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   plugin_platform_interface: ^2.1.8
-  device_info_plus: ^10.1.2
+  device_info_plus: ^11.0.0
   uuid: ^4.5.0
   meta: ^1.15.0
   extension: ^0.6.0


### PR DESCRIPTION
Updated the device info plus version since they did a major release. Not sure why they decided to do so, since the change itself is not that major.

Device info plus release notes here: https://github.com/fluttercommunity/plus_plugins/blob/main/packages/device_info_plus/device_info_plus/CHANGELOG.md