### PR TITLE
[PDFX] Migrate to SurfaceProducer

### DIFF
--- a/packages/pdfx/android/src/main/kotlin/io/scer/pdfx/Messages.kt
+++ b/packages/pdfx/android/src/main/kotlin/io/scer/pdfx/Messages.kt
@@ -31,7 +31,7 @@ class Messages(private val binding : FlutterPlugin.FlutterPluginBinding,
                private val documents: DocumentRepository,
                private val pages: PageRepository) : Pigeon.PdfxApi {
 
-    private val textures: SparseArray<TextureRegistry.SurfaceTextureEntry> = SparseArray()
+    private val textures: SparseArray<TextureRegistry.SurfaceProducer> = SparseArray()
 
     override fun openDocumentData(
         message: Pigeon.OpenDataMessage,
@@ -207,7 +207,7 @@ class Messages(private val binding : FlutterPlugin.FlutterPluginBinding,
     }
 
     override fun registerTexture(): Pigeon.RegisterTextureReply {
-        val surfaceTexture = binding.textureRegistry.createSurfaceTexture()
+        val surfaceTexture = binding.textureRegistry.createSurfaceProducer()
         val id = surfaceTexture.id().toInt()
         textures.put(id, surfaceTexture)
         val result = Pigeon.RegisterTextureReply()
@@ -253,10 +253,9 @@ class Messages(private val binding : FlutterPlugin.FlutterPluginBinding,
                 val texWidth = message.textureWidth!!.toInt()
                 val texHeight = message.textureHeight!!.toInt()
                 if (texWidth != 0 && texHeight != 0) {
-                    tex.surfaceTexture().setDefaultBufferSize(texWidth, texHeight)
+                    tex.setSize(texWidth, texHeight)
                 }
-
-                Surface(tex.surfaceTexture()).use {
+                tex.surface.use {
                     val canvas = it.lockCanvas(Rect(destX, destY, width, height))
 
                     canvas.drawBitmap(bmp, destX.toFloat(), destY.toFloat(), null)
@@ -280,7 +279,7 @@ class Messages(private val binding : FlutterPlugin.FlutterPluginBinding,
         val width = message.width!!.toInt()
         val height = message.height!!.toInt()
         val tex = textures[texId]
-        tex?.surfaceTexture()?.setDefaultBufferSize(width, height)
+        tex?.setSize(width, height)
         result.success(null)
     }
 

--- a/packages/pdfx/pubspec.yaml
+++ b/packages/pdfx/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.8.0
 
 environment:
   sdk: '>=3.3.0 <4.0.0'
-  flutter: '>=3.19.0'
+  flutter: '>=3.24.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Migrates SurfaceTexture to SurfaceProducer for Impeller android support. Resolves #521

Possibly TODO: 
- Support callback for redrawing producers if they are destroyed

https://docs.flutter.dev/release/breaking-changes/android-surface-plugins