### PR TITLE
feat: remove device_info_plus dependency

### DIFF
--- a/packages/pdfx/lib/src/renderer/has_pdf_support.dart
+++ b/packages/pdfx/lib/src/renderer/has_pdf_support.dart
@@ -1,20 +1,14 @@
 import 'dart:async';
 
-import 'package:device_info_plus/device_info_plus.dart';
 import 'package:universal_platform/universal_platform.dart';
-
-final _deviceInfo = DeviceInfoPlugin();
 
 Future<bool> hasPdfSupport() async {
   if (UniversalPlatform.isMacOS ||
       UniversalPlatform.isIOS ||
       UniversalPlatform.isWindows ||
-      UniversalPlatform.isWeb) {
+      UniversalPlatform.isWeb ||
+      UniversalPlatform.isAndroid) {
     return true;
-  }
-  if (UniversalPlatform.isAndroid) {
-    final androidInfo = await _deviceInfo.androidInfo;
-    return androidInfo.version.sdkInt >= 21;
   }
   return false;
 }

--- a/packages/pdfx/pubspec.yaml
+++ b/packages/pdfx/pubspec.yaml
@@ -14,7 +14,6 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   plugin_platform_interface: ^2.1.8
-  device_info_plus: ^11.0.0
   uuid: ^4.5.0
   meta: ^1.15.0
   extension: ^0.6.0


### PR DESCRIPTION
The _plus packages are notorious for breaking version constraints. Having them as a transitive dependency in another library (for example pdfx) increases the risk of dependency hell.

Flutter itself only support Android API level 21 and newer (https://docs.flutter.dev/reference/supported-platforms).
So this check is never false.
