### PR TITLE
Fix android build: Getting error "No value passed for parameter 'forPrint'."

### DIFF
--- a/packages/pdfx/android/src/main/kotlin/io/scer/pdfx/Messages.kt
+++ b/packages/pdfx/android/src/main/kotlin/io/scer/pdfx/Messages.kt
@@ -208,7 +208,7 @@ class Messages(private val binding : FlutterPlugin.FlutterPluginBinding,
 
                 //  background thread render
                 val pageImage = page.render(
-                    tempOutFile, width, height, color, format, crop, cropX, cropY, cropW, cropH, quality
+                    tempOutFile, width, height, color, format, crop, cropX, cropY, cropW, cropH, quality, forPrint = false
                 )
 
                 withContext(Dispatchers.Main) {

--- a/packages/pdfx/ios/Classes/Document.swift
+++ b/packages/pdfx/ios/Classes/Document.swift
@@ -76,8 +76,8 @@ class Page {
         var success = false
         var transform = renderer.getDrawingTransform(.mediaBox, rect: CGRect(origin: CGPoint.zero, size: bitmapSize), rotate: 0, preserveAspectRatio: true)
         let compressionQuality = CGFloat(quality) / 100
-        tempData.withUnsafeMutableBytes { (ptr) in
-            let rawPtr = ptr.baseAddress
+        tempData.withUnsafeMutableBytes { (ptr: UnsafeMutableRawBufferPointer) in
+            guard let rawPtr = ptr.baseAddress else { return }
             let rgb = CGColorSpaceCreateDeviceRGB()
             let context = CGContext(data: rawPtr, width: Int(bitmapSize.width), height: Int(bitmapSize.height), bitsPerComponent: 8, bytesPerRow: stride, space: rgb, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
             if context != nil {

--- a/packages/pdfx/ios/Classes/Hooks.swift
+++ b/packages/pdfx/ios/Classes/Hooks.swift
@@ -1,6 +1,7 @@
 import Foundation
+import UIKit
 
-extension NSColor {
+extension UIColor {
     convenience init(hexString: String) {
         let hex = hexString.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
         var int: UInt64 = UInt64()


### PR DESCRIPTION
The error getting: No value passed for parameter 'forPrint', in the pdfx package is because the method being called in Messages.kt requires a new parameter (forPrint) which is missing in your build.
