### PR TITLE
update messages.kt to pass forPrint for page.render

### DIFF
--- a/packages/pdfx/android/src/main/kotlin/io/scer/pdfx/Messages.kt
+++ b/packages/pdfx/android/src/main/kotlin/io/scer/pdfx/Messages.kt
@@ -208,7 +208,7 @@ class Messages(private val binding : FlutterPlugin.FlutterPluginBinding,
 
                 //  background thread render
                 val pageImage = page.render(
-                    tempOutFile, width, height, color, format, crop, cropX, cropY, cropW, cropH, quality
+                    tempOutFile, width, height, color, format, crop, cropX, cropY, cropW, cropH, quality, forPrint 
                 )
 
                 withContext(Dispatchers.Main) {
@@ -267,6 +267,7 @@ class Messages(private val binding : FlutterPlugin.FlutterPluginBinding,
             val srcX = message.sourceX!!.toInt()
             val srcY = message.sourceY!!.toInt()
             val backgroundColor = message.backgroundColor
+            val forPrint = message.forPrint ?: false;
 
             if (width <= 0 || height <= 0) {
                 result.error(PdfRendererException("pdf_renderer", "updateTexture width/height == 0", null))

--- a/packages/pdfx/android/src/main/kotlin/io/scer/pdfx/Messages.kt
+++ b/packages/pdfx/android/src/main/kotlin/io/scer/pdfx/Messages.kt
@@ -84,7 +84,7 @@ class Messages(private val binding : FlutterPlugin.FlutterPluginBinding,
 
     override fun openDocumentAsset(
         message: Pigeon.OpenPathMessage,
-        result: Pigeon.Result<Pigeon.OpenReply>
+        result: Pigeon.Result<Pigeon.OpenReply>val resultResponse = Pigeon.RenderPageReply()
     ) {
         val resultResponse = Pigeon.OpenReply()
         try {
@@ -186,6 +186,7 @@ class Messages(private val binding : FlutterPlugin.FlutterPluginBinding,
                 val cropW = if (crop) message.width?.toInt() ?: 0 else 0
 
                 val quality = message.quality?.toInt() ?: 100
+                val forPrint = message.forPrint ?: false
 
                 val page = pages.get(pageId)
                 if (page == null) {
@@ -267,7 +268,7 @@ class Messages(private val binding : FlutterPlugin.FlutterPluginBinding,
             val srcX = message.sourceX!!.toInt()
             val srcY = message.sourceY!!.toInt()
             val backgroundColor = message.backgroundColor
-            val forPrint = message.forPrint ?: false;
+           
 
             if (width <= 0 || height <= 0) {
                 result.error(PdfRendererException("pdf_renderer", "updateTexture width/height == 0", null))


### PR DESCRIPTION
This pull request includes changes to the `Messages` class in the `packages/pdfx/android/src/main/kotlin/io/scer/pdfx/Messages.kt` file to support a new `forPrint` parameter in the PDF rendering process.

Enhancements to PDF rendering:

* Added the `forPrint` parameter to the `page.render` method call to allow for print-specific rendering options.
* Introduced the `forPrint` variable, which defaults to `false` if not provided, to handle the new rendering parameter.