### PR TITLE
Expose InteractiveViewer onInteraction-methods

### DIFF
--- a/packages/pdfx/lib/src/viewer/pinch/pdf_view_pinch.dart
+++ b/packages/pdfx/lib/src/viewer/pinch/pdf_view_pinch.dart
@@ -26,6 +26,9 @@ class PdfViewPinch extends StatefulWidget {
     this.onPageChanged,
     this.onDocumentLoaded,
     this.onDocumentError,
+    this.onInteractionStart,
+    this.onInteractionUpdate,
+    this.onInteractionEnd,
     this.builders = const PdfViewPinchBuilders<DefaultBuilderOptions>(
       options: DefaultBuilderOptions(),
     ),
@@ -75,6 +78,15 @@ class PdfViewPinch extends StatefulWidget {
 
   /// Pdf widget page background decoration
   final BoxDecoration backgroundDecoration;
+
+  /// Called when the user starts a pan or scale gesture on the widget.
+  final GestureScaleStartCallback? onInteractionStart;
+
+  /// Called when the user ends a pan or scale gesture on the widget.
+  final GestureScaleEndCallback? onInteractionEnd;
+
+  /// Called when the user updates a pan or scale gesture on the widget.
+  final GestureScaleUpdateCallback? onInteractionUpdate;
 
   /// Default page builder
   @override
@@ -564,6 +576,9 @@ class _PdfViewPinchState extends State<PdfViewPinch>
         _reLayout(viewSize);
         final docSize = _docSize ?? const Size(10, 10); // dummy size
         return InteractiveViewer(
+          onInteractionStart: widget.onInteractionStart,
+          onInteractionEnd: widget.onInteractionEnd,
+          onInteractionUpdate: widget.onInteractionUpdate,
           transformationController: _controller,
           scrollControls: InteractiveViewerScrollControls.scrollPans,
           constrained: false,


### PR DESCRIPTION
We needed to know when the user starts to zoom the pdf, so we needed to expose the onInteractionStart/-End-methods so we can scale our overlay which we have on top. 