### PR TITLE
pdfx: fix error if rawDocumentProgress is NaN

### DIFF
--- a/packages/pdfx/lib/src/viewer/pinch/pdf_view_pinch.dart
+++ b/packages/pdfx/lib/src/viewer/pinch/pdf_view_pinch.dart
@@ -291,9 +291,14 @@ class _PdfViewPinchState extends State<PdfViewPinch>
         -m.row0[3], -m.row1[3], _lastViewSize!.width, _lastViewSize!.height);
 
     if (_lastViewSize?.height != null) {
-      final rawDocumentProgress =
+      var rawDocumentProgress =
           ((exposed.bottom / r - _lastViewSize!.height) /
               (_docSize!.height - _lastViewSize!.height));
+
+      if (rawDocumentProgress.isNaN || rawDocumentProgress.isInfinite) {
+        rawDocumentProgress = 0.0;
+      }
+
       const precisionFactor = 10000;
       _controller._documentProgress =
           ((rawDocumentProgress * precisionFactor).round() / precisionFactor)


### PR DESCRIPTION
Using pdfx 2.9.2, and also when using the latest changes on main.

I'm seeing the PDF widget render as a white block on iOS, or very occasionally a red Flutter error:

It seems to be fine if using Axis.vertical but not when using horizontal scrolling:

```dart
PdfViewPinch(
    controller: pdfControllerPinch,
    builders: PdfViewPinchBuilders<DefaultBuilderOptions>(
      options: const DefaultBuilderOptions(
        loaderSwitchDuration: Duration(seconds: 1),
      ),
      documentLoaderBuilder: (_) =>
          const Center(child: CircularProgressIndicator()),
      pageLoaderBuilder: (_) =>
          const Center(child: CircularProgressIndicator()),
      errorBuilder: (_, error) => Center(child: Text(error.toString())),
    ),
    scrollDirection: Axis.horizontal,
  ),
)
```

<img width="371" height="646" alt="image" src="https://github.com/user-attachments/assets/9f9928e7-639f-46ed-a4c7-878d00a2beeb" />

<img width="371" height="646" alt="image" src="https://github.com/user-attachments/assets/af5025ed-76a5-4de6-9edf-e75475308b1f" />


The error in my logs is:

```
flutter: ├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
flutter: │ ⛔ [ERROR] [main] Flutter framework error
flutter: └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
flutter: ┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
flutter: │ Unsupported operation: Infinity or NaN toInt
flutter: ├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
flutter: │ #3   _PdfViewPinchState._reLayout.<anonymous closure> (package:pdfx/src/viewer/pinch/pdf_view_pinch.dart:234:11)
pdf_view_pinch.dart:234
flutter: │ #4   new Future.delayed.<anonymous closure> (dart:async/future.dart:419:42)
future.dart:419
flutter: │ #5   _rootRun (dart:async/zone.dart:1517:47)
zone.dart:1517
flutter: │ #6   _CustomZone.run (dart:async/zone.dart:1422:19)
zone.dart:1422
flutter: │ #7   _CustomZone.runGuarded (dart:async/zone.dart:1321:7)
```

Which through debugging is caused by [line 298 of pdf_view_pinch.dart](https://github.com/ScerIO/packages.flutter/blob/3a52e368c0d117d32e748304c816bc6be142ce48/packages/pdfx/lib/src/viewer/pinch/pdf_view_pinch.dart#L298) inside _determinePagesToShow():

```dart
 _controller._documentProgress =
     ((rawDocumentProgress * precisionFactor).round() / precisionFactor)
         .clamp(0.0, 1.0);
```

In my case, the rawDocumentProgress calculation ended up being `(503.15789473684214 - 503.15789473684214) / (503.15789473684214 - 503.15789473684214)` = 0/0 which results in a NaN in Flutter.

<img width="1470" height="531" alt="image" src="https://github.com/user-attachments/assets/a1e7af2b-5b1d-4203-b8dc-8c7c8bc7a60c" />

This PR adds a check to set the progress to 0 if rawDocumentProgress is NaN.

It seems to work OK, but I have no idea if this will have any negative effects elsewhere

Thanks