### PR TITLE
Fix explorer intl constraint blocking pub get

### DIFF
--- a/packages/explorer/pubspec.yaml
+++ b/packages/explorer/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter     
-  intl: ^0.18.0
+  intl: ^0.20.3
   flutter_breadcrumb: ^1.0.1
   auto_animated: ^3.1.0
   sliver_tools: ^0.2.10


### PR DESCRIPTION
## Summary
- `explorer/pubspec.yaml` pinned `intl: ^0.18.0`, but `flutter_localizations` in the current Flutter SDK requires `intl ^0.20.3`, so `pub get` failed outright for this package on a fresh clone.
- With dependencies never resolved, the analyzer reported hundreds of cascading false positives (`undefined_identifier`, `undefined_class`, `uri_does_not_exist`, etc.) across the package, since even `flutter_lints` could not be found.
- Bump the constraint to `^0.20.3` so `pub get` succeeds; real analyzer issue count for the package drops from 545 to 10 (minor lint style warnings only).

## Test plan
- [x] `flutter pub get` succeeds in `packages/explorer`
- [x] `dart analyze` in `packages/explorer` goes from 545 issues to 10