### PR TITLE
Fix remaining lint warnings in explorer example

### DIFF
--- a/packages/explorer/example/lib/main.dart
+++ b/packages/explorer/example/lib/main.dart
@@ -21,7 +21,7 @@ class MyApp extends StatefulWidget {
   final Directory appDocDir;
 
   @override
-  _MyAppState createState() => _MyAppState();
+  State<MyApp> createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
@@ -46,7 +46,7 @@ class _MyAppState extends State<MyApp> {
 
   void filePressed(ExplorerFile file) {
     if ((file.size ?? 0) > 200000) {
-      final snackBar =
+      const snackBar =
           SnackBar(content: Text('Can\'t open files with size > 200kb'));
 
       // Find the Scaffold in the widget tree and use it to show a SnackBar.
@@ -57,23 +57,23 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) => MaterialApp(
-        localizationsDelegates: [
+        localizationsDelegates: const [
           ExplorerLocalizationsDelegate(),
           GlobalMaterialLocalizations.delegate,
           GlobalWidgetsLocalizations.delegate,
         ],
-        supportedLocales: [
-          const Locale('en', ''),
-          const Locale('ru', ''),
-          const Locale('fr', ''),
+        supportedLocales: const [
+          Locale('en', ''),
+          Locale('ru', ''),
+          Locale('fr', ''),
         ],
         home: Scaffold(
           body: Explorer(
             controller: _controller,
             builder: (_) => [
-              ExplorerToolbar(),
-              ExplorerActionView(),
-              ExplorerFilesGridView(),
+              const ExplorerToolbar(),
+              const ExplorerActionView(),
+              const ExplorerFilesGridView(),
             ],
             filePressed: filePressed,
           ),

--- a/packages/explorer/example/pubspec.lock
+++ b/packages/explorer/example/pubspec.lock
@@ -110,7 +110,7 @@ packages:
     source: hosted
     version: "1.0.1"
   flutter_localizations:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/packages/explorer/example/pubspec.yaml
+++ b/packages/explorer/example/pubspec.yaml
@@ -8,6 +8,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   path_provider: ^2.0.11
   explorer:
     path: ../


### PR DESCRIPTION
## Summary
- Follow-up to #627, now that pub get resolves cleanly: fix the 10 remaining real lint warnings in `explorer/example`.
- Add `flutter_localizations` as a direct dependency instead of only relying on it transitively through `flutter_localizations.dart` import.
- Return the public `State<MyApp>` type from `createState`, matching `library_private_types_in_public_api`.
- Add the missing `const` constructors flagged by `prefer_const_constructors` / `prefer_const_literals_to_create_immutables`.

## Test plan
- [x] `dart analyze` in `packages/explorer` reports no issues