### PR TITLE
Replace deprecated Color int accessors with the double-based API

### DIFF
--- a/packages/flutter_color/lib/src/helper.dart
+++ b/packages/flutter_color/lib/src/helper.dart
@@ -5,9 +5,9 @@ extension ColorHelper on Color {
   Color lighter(int percents) {
     assert(percents >= 1 && percents <= 100);
     final int rgbPercent = (percents / 100 * 255).round();
-    int red = this.red + rgbPercent,
-        green = this.green + rgbPercent,
-        blue = this.blue + rgbPercent;
+    int red = (this.r * 255.0).round() + rgbPercent,
+        green = (this.g * 255.0).round() + rgbPercent,
+        blue = (this.b * 255.0).round() + rgbPercent;
     if (red > 255) {
       red = 255;
     }
@@ -17,16 +17,16 @@ extension ColorHelper on Color {
     if (blue > 255) {
       blue = 255;
     }
-    return Color.fromARGB(alpha, red, green, blue);
+    return Color.fromARGB((this.a * 255.0).round(), red, green, blue);
   }
 
   /// Make color darker by so many [percents]
   Color darker(int percents) {
     assert(percents >= 1 && percents <= 100);
     final int rgbPercent = (percents / 100 * 255).round();
-    int red = this.red - rgbPercent,
-        green = this.green - rgbPercent,
-        blue = this.blue - rgbPercent;
+    int red = (this.r * 255.0).round() - rgbPercent,
+        green = (this.g * 255.0).round() - rgbPercent,
+        blue = (this.b * 255.0).round() - rgbPercent;
     if (red < 0) {
       red = 0;
     }
@@ -36,7 +36,7 @@ extension ColorHelper on Color {
     if (blue < 0) {
       blue = 0;
     }
-    return Color.fromARGB(alpha, red, green, blue);
+    return Color.fromARGB((this.a * 255.0).round(), red, green, blue);
   }
 
   /// Linearly interpolate between two colors.
@@ -64,5 +64,5 @@ extension ColorHelper on Color {
   Color? mix(Color another, double amount) => Color.lerp(this, another, amount);
 
   /// Convert color to hex string
-  String get asHexString => '#${value.toRadixString(16).toUpperCase()}';
+  String get asHexString => '#${toARGB32().toRadixString(16).toUpperCase()}';
 }

--- a/packages/flutter_color/test/flutter_color_test.dart
+++ b/packages/flutter_color/test/flutter_color_test.dart
@@ -6,15 +6,18 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   group('hex color', () {
     test('Normal color', () {
-      expect(HexColor('#FFFFFF').value, equals(const Color(0xFFFFFFFF).value));
-      expect(HexColor('FFFFFF').value, equals(const Color(0xFFFFFFFF).value));
+      expect(HexColor('#FFFFFF').toARGB32(),
+          equals(const Color(0xFFFFFFFF).toARGB32()));
+      expect(HexColor('FFFFFF').toARGB32(),
+          equals(const Color(0xFFFFFFFF).toARGB32()));
     });
     test('Color with transparent', () {
-      expect(
-          HexColor('#B1FFFFFF').value, equals(const Color(0xB1FFFFFF).value));
-      expect(
-          HexColor('#00FFFFFF').value, equals(const Color(0x00FFFFFF).value));
-      expect(HexColor('00FFFFFF').value, equals(const Color(0x00FFFFFF).value));
+      expect(HexColor('#B1FFFFFF').toARGB32(),
+          equals(const Color(0xB1FFFFFF).toARGB32()));
+      expect(HexColor('#00FFFFFF').toARGB32(),
+          equals(const Color(0x00FFFFFF).toARGB32()));
+      expect(HexColor('00FFFFFF').toARGB32(),
+          equals(const Color(0x00FFFFFF).toARGB32()));
     });
   });
 


### PR DESCRIPTION
## Summary
- `Color.red/green/blue/alpha/value` are deprecated in the current Flutter SDK, which represents color channels as floats (`r/g/b/a`, 0.0-1.0) instead of ints (0-255).
- Update `lighter`/`darker`/`asHexString` in `flutter_color`'s `ColorHelper` extension to use the new accessors, converting to the 0-255 int scale where needed.
- Update the tests that compared `.value` to compare `.toARGB32()` instead.

## Test plan
- [x] `dart analyze` in `packages/flutter_color` reports no issues
- [x] `flutter test` in `packages/flutter_color` passes for every test except `Helpers mix`, which already fails on `main` before this change (unrelated float precision difference in `Color.lerp`, not touched here)