### PR TITLE
Replace deprecated Matrix4 translate/scale with the typed API

### DIFF
--- a/packages/pdfx/lib/src/viewer/interactive_viewer.dart
+++ b/packages/pdfx/lib/src/viewer/interactive_viewer.dart
@@ -859,9 +859,11 @@ class _InteractiveViewerState extends State<InteractiveViewer>
         : translation;
 
     final Matrix4 nextMatrix = matrix.clone()
-      ..translate(
+      ..translateByDouble(
         alignedTranslation.dx,
         alignedTranslation.dy,
+        0.0,
+        1.0,
       );
 
     // Transform the viewport to determine where its four corners will be after
@@ -967,7 +969,8 @@ class _InteractiveViewerState extends State<InteractiveViewer>
       widget.maxScale,
     );
     final double clampedScale = clampedTotalScale / currentScale;
-    return matrix.clone()..scale(clampedScale);
+    return matrix.clone()
+      ..scaleByDouble(clampedScale, clampedScale, clampedScale, 1.0);
   }
 
   // Return a new matrix representing the given matrix after applying the given
@@ -980,9 +983,9 @@ class _InteractiveViewerState extends State<InteractiveViewer>
       focalPoint,
     );
     return matrix.clone()
-      ..translate(focalPointScene.dx, focalPointScene.dy)
+      ..translateByDouble(focalPointScene.dx, focalPointScene.dy, 0.0, 1.0)
       ..rotateZ(-rotation)
-      ..translate(-focalPointScene.dx, -focalPointScene.dy);
+      ..translateByDouble(-focalPointScene.dx, -focalPointScene.dy, 0.0, 1.0);
   }
 
   // Returns true iff the given _GestureType is enabled.
@@ -1595,9 +1598,14 @@ Quad _transformViewport(Matrix4 matrix, Rect viewport) {
 // the given amount.
 Quad _getAxisAlignedBoundingBoxWithRotation(Rect rect, double rotation) {
   final Matrix4 rotationMatrix = Matrix4.identity()
-    ..translate(rect.size.width / 2, rect.size.height / 2)
+    ..translateByDouble(rect.size.width / 2, rect.size.height / 2, 0.0, 1.0)
     ..rotateZ(rotation)
-    ..translate(-rect.size.width / 2, -rect.size.height / 2);
+    ..translateByDouble(
+      -rect.size.width / 2,
+      -rect.size.height / 2,
+      0.0,
+      1.0,
+    );
   final Quad boundariesRotated = Quad.points(
     rotationMatrix.transform3(Vector3(rect.left, rect.top, 0.0)),
     rotationMatrix.transform3(Vector3(rect.right, rect.top, 0.0)),


### PR DESCRIPTION
## Summary
- `Matrix4.translate` and `Matrix4.scale` are deprecated in the current `vector_math`, in favor of `translateByDouble`/`scaleByDouble` (or the Vector3/Vector4 variants).
- Replace the 5 deprecated call sites in `interactive_viewer.dart` with the equivalent typed calls.

## Test plan
- [x] `dart analyze` in `packages/pdfx` reports no issues
- [x] `flutter test` in `packages/pdfx` passes