### PR TITLE
Fix deprecated window usage and a style lint in epub_view

### DIFF
--- a/packages/epub_view/example/lib/main.dart
+++ b/packages/epub_view/example/lib/main.dart
@@ -30,8 +30,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   }
 
   Brightness get platformBrightness =>
-      MediaQueryData.fromView(WidgetsBinding.instance.window)
-          .platformBrightness;
+      WidgetsBinding.instance.platformDispatcher.platformBrightness;
 
   void _setSystemUIOverlayStyle() {
     if (platformBrightness == Brightness.light) {

--- a/packages/epub_view/lib/src/data/epub_cfi/_parser.dart
+++ b/packages/epub_view/lib/src/data/epub_cfi/_parser.dart
@@ -1039,7 +1039,7 @@ class EpubCfiParser {
     }
     if (result0 != null) {
       result0 = ((offset, intPartVal, fracPartVal) =>
-              intPartVal.join('') + '.' + fracPartVal.join(''))(
+              '${intPartVal.join('')}.${fracPartVal.join('')}')(
           pos0, result0[0], result0[2]);
     }
     if (result0 == null) {


### PR DESCRIPTION
## Summary
- `WidgetsBinding.instance.window` is deprecated ahead of multi-window support; read `platformBrightness` from `WidgetsBinding.instance.platformDispatcher` instead in the example app.
- Fix a `prefer_interpolation_to_compose_strings` lint in the CFI parser by using string interpolation instead of concatenation.

## Test plan
- [x] `dart analyze` in `packages/epub_view` reports no issues
- [x] `flutter test` in `packages/epub_view` passes