### PR TITLE
Remove unnecessary null checks in Xcode.runXcodeBuild

### DIFF
--- a/script/tool/lib/src/common/xcode.dart
+++ b/script/tool/lib/src/common/xcode.dart
@@ -42,8 +42,8 @@ class Xcode {
     final List<String> args = <String>[
       _xcodeBuildCommand,
       ...actions,
-      if (workspace != null) ...<String>['-workspace', workspace],
-      if (scheme != null) ...<String>['-scheme', scheme],
+      '-workspace', workspace,
+      '-scheme', scheme,
       if (configuration != null) ...<String>['-configuration', configuration],
       ...extraFlags,
     ];


### PR DESCRIPTION
## Summary
- `workspace` and `scheme` in `Xcode.runXcodeBuild` are `required String` (non-nullable), so the `if (workspace != null)` / `if (scheme != null)` guards around them are dead code, flagged by `unnecessary_null_comparison`.
- Pass them unconditionally instead, no behavior change.

## Test plan
- [x] `dart analyze` in `script/tool` reports no issues