### PR TITLE
[pdfx] Move pdf.js presence check from plugin registration to document open

### DIFF
--- a/packages/pdfx/CHANGELOG.md
+++ b/packages/pdfx/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.9.3
+
+* Web: moved the pdf.js presence check from plugin registration to document
+  open, so apps that depend on pdfx without opening a PDF no longer fail to
+  start when pdf.js is not in web/index.html
+
 ## 2.9.2
 
 * Fixed PdfViewPinch when compiling to WASM [pull#586](https://github.com/ScerIO/packages.flutter/pull/586)

--- a/packages/pdfx/lib/src/renderer/web/platform.dart
+++ b/packages/pdfx/lib/src/renderer/web/platform.dart
@@ -24,11 +24,13 @@ final _textures = <int, RgbaData>{};
 int _texId = -1;
 
 class PdfxWeb extends PdfxPlatform {
+  // The pdf.js presence check deliberately does NOT run here: this
+  // constructor runs during web plugin registration for every app that
+  // merely depends on pdfx, so a missing script killed apps (and tools such
+  // as the widget previewer) that never open a PDF. The check lives in
+  // _openDocumentData instead, the funnel every open path goes through, so
+  // it fires only when a PDF is actually opened.
   PdfxWeb() {
-    assert(
-        checkPdfjsLibInstallation(),
-        'pdf.js not added in web/index.html. '
-        'Run «flutter pub run pdfx:install_web» or add script manually');
     _eventChannel.setController(_eventStreamController);
   }
 
@@ -44,6 +46,12 @@ class PdfxWeb extends PdfxPlatform {
 
   Future<DocumentInfo> _openDocumentData(ByteBuffer data,
       {String? password}) async {
+    // A StateError (not an assert) so release builds also fail with a clear
+    // message instead of an obscure pdf.js JS error.
+    if (!checkPdfjsLibInstallation()) {
+      throw StateError('pdf.js not added in web/index.html. '
+          'Run «flutter pub run pdfx:install_web» or add script manually');
+    }
     final document = await pdfjsGetDocumentFromData(data, password: password);
 
     return _documents.register(document).info;

--- a/packages/pdfx/pubspec.yaml
+++ b/packages/pdfx/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdfx
 description: Flutter plugin to render & show PDF pages as images on Web, MacOS, Windows, Android and iOS.
 repository: https://github.com/ScerIO/packages.flutter/tree/main/packages/pdfx
 issue_tracker: https://github.com/ScerIO/packages.flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pdfx%22
-version: 2.9.2
+version: 2.9.3
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
## Description

The web plugin's `PdfxWeb()` constructor asserts that pdf.js is present in `web/index.html`. Since the constructor runs during Flutter web plugin registration, any app that merely **depends** on pdfx — without ever opening a PDF — fails to start when the script is missing. This also breaks tooling that web-compiles apps automatically, such as the Flutter widget previewer (`flutter widget-preview start`), which generates its own `index.html` with no way to inject the script.

## Changes

- Moved the pdf.js presence check from the `PdfxWeb` constructor to `_openDocumentData`, the funnel every document-open path goes through, so it fires only when a PDF is actually opened.
- Upgraded it from `assert` to a `StateError` throw, so release builds also fail with the clear "pdf.js not added in web/index.html" message instead of an obscure pdf.js JS error. Message text unchanged.
- CHANGELOG entry + version bump to 2.9.3 (happy to drop/adjust these if you prefer to handle versioning yourself).

## Behaviour

- With pdf.js installed: identical behaviour.
- Without pdf.js: the app now starts normally and fails with the existing clear message at the moment a PDF is opened, rather than at app startup.