### PR TITLE
Add NEXT changelog entries for recently merged changes

### DIFF
--- a/packages/epub_view/CHANGELOG.md
+++ b/packages/epub_view/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Added support for opening books from a URL via `EpubDocument.openUrl` [pull#470](https://github.com/ScerIO/packages.flutter/pull/470)
+
 ## 3.2.0
 
 * Upgrade epubx dependency

--- a/packages/explorer/CHANGELOG.md
+++ b/packages/explorer/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Fixed `intl` constraint that could block `pub get` on newer Flutter SDKs [pull#627](https://github.com/ScerIO/packages.flutter/pull/627)
+
 ## 2.3.0
 
 * Upgrade dependencies

--- a/packages/flutter_color/CHANGELOG.md
+++ b/packages/flutter_color/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Replaced deprecated `Color.red`/`green`/`blue`/`alpha`/`value` accessors with the float-based API [pull#629](https://github.com/ScerIO/packages.flutter/pull/629)
+
 ## 2.1.0
 
 * Upgrade dependencies

--- a/packages/pdfx/CHANGELOG.md
+++ b/packages/pdfx/CHANGELOG.md
@@ -1,3 +1,13 @@
+## NEXT
+
+* Supported AGP 9 built-in Kotlin [pull#624](https://github.com/ScerIO/packages.flutter/pull/624)
+* Supported Windows ARM64 build [pull#620](https://github.com/ScerIO/packages.flutter/pull/620)
+* Fixed Windows build failure on CMake < 3.24 [pull#612](https://github.com/ScerIO/packages.flutter/pull/612)
+* Fixed WASM incompatibilities [pull#611](https://github.com/ScerIO/packages.flutter/pull/611)
+* Exposed `onInteractionStart`/`onInteractionUpdate`/`onInteractionEnd` on `PdfViewPinch` [pull#594](https://github.com/ScerIO/packages.flutter/pull/594)
+* Replaced deprecated `Matrix4.translate`/`Matrix4.scale` calls [pull#630](https://github.com/ScerIO/packages.flutter/pull/630)
+* Updated docs to use `dart run` instead of the deprecated `flutter pub run` [pull#597](https://github.com/ScerIO/packages.flutter/pull/597)
+
 ## 2.9.2
 
 * Fixed PdfViewPinch when compiling to WASM [pull#586](https://github.com/ScerIO/packages.flutter/pull/586)


### PR DESCRIPTION
## Summary
- Add `## NEXT` sections to the CHANGELOG.md of the packages with pertinent merged changes since their last published version, using the repo's existing NEXT convention.
- **pdfx**: AGP 9 built-in Kotlin support, Windows ARM64 build, CMake <3.24 build fix, WASM fixes, exposed `PdfViewPinch` interaction callbacks, deprecated `Matrix4` API cleanup, and doc updates.
- **epub_view**: `EpubDocument.openUrl` support.
- **explorer**: fixed `intl` constraint that could block `pub get` on newer Flutter SDKs.
- **flutter_color**: replaced deprecated `Color` int accessors with the float-based API.
- Internal-only or example-app-only changes (gitignore/lockfile hygiene, example lint fixes, doc-only script comment updates) were left out as not consumer-relevant.

## Test plan
- [x] `dart run script/tool/bin/flutter_plugin_tools.dart version-check --base-sha=HEAD --packages=pdfx,epub_view,explorer,flutter_color` reports no issues