### PR TITLE
[pdfx] Move pdf.js presence check from plugin registration to document open

### DIFF
--- a/packages/pdfx/CHANGELOG.md
+++ b/packages/pdfx/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Exposed `onInteractionStart`/`onInteractionUpdate`/`onInteractionEnd` on `PdfViewPinch` [pull#594](https://github.com/ScerIO/packages.flutter/pull/594)
 * Replaced deprecated `Matrix4.translate`/`Matrix4.scale` calls [pull#630](https://github.com/ScerIO/packages.flutter/pull/630)
 * Updated docs to use `dart run` instead of the deprecated `flutter pub run` [pull#597](https://github.com/ScerIO/packages.flutter/pull/597)
+* Web: moved the pdf.js presence check from plugin registration to document open, so apps that depend on pdfx without opening a PDF no longer fail to start when pdf.js is not in web/index.html [pull#633](https://github.com/ScerIO/packages.flutter/pull/633)
 
 ## 2.9.2
 

--- a/packages/pdfx/lib/src/renderer/web/platform.dart
+++ b/packages/pdfx/lib/src/renderer/web/platform.dart
@@ -24,11 +24,13 @@ final _textures = <int, RgbaData>{};
 int _texId = -1;
 
 class PdfxWeb extends PdfxPlatform {
+  // The pdf.js presence check deliberately does NOT run here: this
+  // constructor runs during web plugin registration for every app that
+  // merely depends on pdfx, so a missing script killed apps (and tools such
+  // as the widget previewer) that never open a PDF. The check lives in
+  // _openDocumentData instead, the funnel every open path goes through, so
+  // it fires only when a PDF is actually opened.
   PdfxWeb() {
-    assert(
-        checkPdfjsLibInstallation(),
-        'pdf.js not added in web/index.html. '
-        'Run «dart run pdfx:install_web» or add script manually');
     _eventChannel.setController(_eventStreamController);
   }
 
@@ -44,6 +46,12 @@ class PdfxWeb extends PdfxPlatform {
 
   Future<DocumentInfo> _openDocumentData(ByteBuffer data,
       {String? password}) async {
+    // A StateError (not an assert) so release builds also fail with a clear
+    // message instead of an obscure pdf.js JS error.
+    if (!checkPdfjsLibInstallation()) {
+      throw StateError('pdf.js not added in web/index.html. '
+          'Run «dart run pdfx:install_web» or add script manually');
+    }
     final document = await pdfjsGetDocumentFromData(data, password: password);
 
     return _documents.register(document).info;


### PR DESCRIPTION
Rebase of #633 by @hadiyarajesh onto main, with the CHANGELOG/version adjustment requested there: dropped the direct 2.9.3 bump and folded the entry into the accumulating `## NEXT` section instead, alongside the other unreleased pdfx changes. No functional changes beyond #633's original diff.

Original description from #633:

The web plugin's `PdfxWeb()` constructor asserts that pdf.js is present in `web/index.html`. Since the constructor runs during Flutter web plugin registration, any app that merely depends on pdfx — without ever opening a PDF — fails to start when the script is missing. This also breaks tooling that web-compiles apps automatically, such as the Flutter widget previewer (`flutter widget-preview start`), which generates its own `index.html` with no way to inject the script.

- Moved the pdf.js presence check from the `PdfxWeb` constructor to `_openDocumentData`, the funnel every document-open path goes through, so it fires only when a PDF is actually opened.
- Upgraded it from `assert` to a `StateError` throw, so release builds also fail with the clear "pdf.js not added in web/index.html" message instead of an obscure pdf.js JS error.

## Test plan
- [x] `dart analyze` in `packages/pdfx` reports no issues
- [x] `dart run script/tool/bin/flutter_plugin_tools.dart version-check --base-sha=HEAD --packages=pdfx` reports no issues