### PR TITLE
Add per package CI testing and automated pub.dev publishing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/auto_animated"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/epub_view"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/explorer"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/flutter_color"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/pdfx"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,97 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*-v*'
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Limit to a single package (leave empty to auto-detect all)'
+        required: false
+        type: choice
+        default: ''
+        options:
+          - ''
+          - auto_animated
+          - epub_view
+          - explorer
+          - flutter_color
+          - pdfx
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.detect.outputs.packages }}
+      has_packages: ${{ steps.detect.outputs.has_packages }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: detect
+        run: |
+          set -e
+          TAG_VERSION=""
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # Tag format is <package>-v<version>, e.g. auto_animated-v1.2.3
+            TAG="${{ github.ref_name }}"
+            CANDIDATES="${TAG%-v*}"
+            TAG_VERSION="${TAG##*-v}"
+          elif [ -n "${{ inputs.package }}" ]; then
+            CANDIDATES="${{ inputs.package }}"
+          else
+            CANDIDATES="auto_animated epub_view explorer flutter_color pdfx"
+          fi
+
+          TO_PUBLISH="[]"
+          for pkg in $CANDIDATES; do
+            LOCAL_VERSION=$(awk '/^version: */{print $2}' "packages/$pkg/pubspec.yaml" | tr -d '"' | tr -d "'" | tr -d '\r')
+
+            if [ -n "$TAG_VERSION" ] && [ "$LOCAL_VERSION" != "$TAG_VERSION" ]; then
+              echo "::error::Tag $TAG expects version $TAG_VERSION but packages/$pkg/pubspec.yaml has $LOCAL_VERSION"
+              exit 1
+            fi
+
+            PUBLISHED_VERSION=$(curl -s "https://pub.dev/api/packages/$pkg" | jq -r '.latest.version // "0.0.0"')
+
+            # sort -V is not a fully spec-compliant semver comparator (e.g. prerelease
+            # precedence), but it is good enough for this repo's plain x.y.z versions.
+            HIGHEST=$(printf '%s\n%s' "$PUBLISHED_VERSION" "$LOCAL_VERSION" | sort -V | tail -n1)
+
+            if [ "$LOCAL_VERSION" != "$PUBLISHED_VERSION" ] && [ "$HIGHEST" = "$LOCAL_VERSION" ]; then
+              echo "$pkg needs publish: $PUBLISHED_VERSION -> $LOCAL_VERSION"
+              TO_PUBLISH=$(echo "$TO_PUBLISH" | jq -c --arg p "$pkg" '. + [$p]')
+            else
+              echo "$pkg up to date (local=$LOCAL_VERSION, published=$PUBLISHED_VERSION)"
+            fi
+          done
+
+          echo "packages=$TO_PUBLISH" >> "$GITHUB_OUTPUT"
+          if [ "$TO_PUBLISH" = "[]" ]; then
+            echo "has_packages=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_packages=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    needs: detect
+    if: needs.detect.outputs.has_packages == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJson(needs.detect.outputs.packages) }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+        working-directory: packages/${{ matrix.package }}
+      - run: dart pub publish --force
+        working-directory: packages/${{ matrix.package }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,9 @@ jobs:
   test:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.packages != '[]' }}
-    runs-on: ubuntu-latest
+    # pdfx has no Linux support (see lib/src/renderer/has_pdf_support.dart), so it needs a
+    # runner for one of its supported platforms; macOS covers macOS/iOS-class PDF support.
+    runs-on: ${{ matrix.package == 'pdfx' && 'macos-latest' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+name: CI Flutter Packages
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            auto_animated:
+              - 'packages/auto_animated/**'
+            epub_view:
+              - 'packages/epub_view/**'
+            explorer:
+              - 'packages/explorer/**'
+            flutter_color:
+              - 'packages/flutter_color/**'
+            pdfx:
+              - 'packages/pdfx/**'
+
+  test:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.packages != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJson(needs.detect-changes.outputs.packages) }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+        working-directory: packages/${{ matrix.package }}
+      - run: dart format --output=none --set-exit-if-changed .
+        working-directory: packages/${{ matrix.package }}
+      - run: flutter analyze --fatal-infos
+        working-directory: packages/${{ matrix.package }}
+      - run: flutter test
+        working-directory: packages/${{ matrix.package }}

--- a/packages/epub_view/lib/src/helpers/epub_document.dart
+++ b/packages/epub_view/lib/src/helpers/epub_document.dart
@@ -32,6 +32,4 @@ class EpubDocument {
       throw Exception('Failed to load epub');
     }
   }
-
-
 }

--- a/packages/pdfx/lib/src/renderer/io/pigeon.dart
+++ b/packages/pdfx/lib/src/renderer/io/pigeon.dart
@@ -418,97 +418,85 @@ class _PdfxApiCodec extends StandardMessageCodec {
     if (value is GetPageMessage) {
       buffer.putUint8(128);
       writeValue(buffer, value.encode());
-    } else 
-    if (value is GetPageReply) {
+    } else if (value is GetPageReply) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
-    } else 
-    if (value is IdMessage) {
+    } else if (value is IdMessage) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
-    } else 
-    if (value is OpenDataMessage) {
+    } else if (value is OpenDataMessage) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
-    } else 
-    if (value is OpenPathMessage) {
+    } else if (value is OpenPathMessage) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    } else 
-    if (value is OpenReply) {
+    } else if (value is OpenReply) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
-    } else 
-    if (value is RegisterTextureReply) {
+    } else if (value is RegisterTextureReply) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
-    } else 
-    if (value is RenderPageMessage) {
+    } else if (value is RenderPageMessage) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
-    } else 
-    if (value is RenderPageReply) {
+    } else if (value is RenderPageReply) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    } else 
-    if (value is ResizeTextureMessage) {
+    } else if (value is ResizeTextureMessage) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else 
-    if (value is UnregisterTextureMessage) {
+    } else if (value is UnregisterTextureMessage) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else 
-    if (value is UpdateTextureMessage) {
+    } else if (value is UpdateTextureMessage) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else 
-{
+    } else {
       super.writeValue(buffer, value);
     }
   }
+
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 128:       
+      case 128:
         return GetPageMessage.decode(readValue(buffer)!);
-      
-      case 129:       
+
+      case 129:
         return GetPageReply.decode(readValue(buffer)!);
-      
-      case 130:       
+
+      case 130:
         return IdMessage.decode(readValue(buffer)!);
-      
-      case 131:       
+
+      case 131:
         return OpenDataMessage.decode(readValue(buffer)!);
-      
-      case 132:       
+
+      case 132:
         return OpenPathMessage.decode(readValue(buffer)!);
-      
-      case 133:       
+
+      case 133:
         return OpenReply.decode(readValue(buffer)!);
-      
-      case 134:       
+
+      case 134:
         return RegisterTextureReply.decode(readValue(buffer)!);
-      
-      case 135:       
+
+      case 135:
         return RenderPageMessage.decode(readValue(buffer)!);
-      
-      case 136:       
+
+      case 136:
         return RenderPageReply.decode(readValue(buffer)!);
-      
-      case 137:       
+
+      case 137:
         return ResizeTextureMessage.decode(readValue(buffer)!);
-      
-      case 138:       
+
+      case 138:
         return UnregisterTextureMessage.decode(readValue(buffer)!);
-      
-      case 139:       
+
+      case 139:
         return UpdateTextureMessage.decode(readValue(buffer)!);
-      
-      default:      
+
+      default:
         return super.readValueOfType(type, buffer);
-      
     }
   }
 }
@@ -523,7 +511,8 @@ class PdfxApi {
   /// Constructor for [PdfxApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  PdfxApi({BinaryMessenger? binaryMessenger}) : _binaryMessenger = binaryMessenger;
+  PdfxApi({BinaryMessenger? binaryMessenger})
+      : _binaryMessenger = binaryMessenger;
 
   final BinaryMessenger? _binaryMessenger;
 
@@ -531,7 +520,8 @@ class PdfxApi {
 
   Future<OpenReply> openDocumentData(OpenDataMessage arg_message) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.PdfxApi.openDocumentData', codec, binaryMessenger: _binaryMessenger);
+        'dev.flutter.pigeon.PdfxApi.openDocumentData', codec,
+        binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap =
         await channel.send(<Object?>[arg_message]) as Map<Object?, Object?>?;
     if (replyMap == null) {
@@ -540,7 +530,8 @@ class PdfxApi {
         message: 'Unable to establish connection on channel.',
       );
     } else if (replyMap['error'] != null) {
-      final Map<Object?, Object?> error = (replyMap['error'] as Map<Object?, Object?>?)!;
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
       throw PlatformException(
         code: (error['code'] as String?)!,
         message: error['message'] as String?,
@@ -558,7 +549,8 @@ class PdfxApi {
 
   Future<OpenReply> openDocumentFile(OpenPathMessage arg_message) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.PdfxApi.openDocumentFile', codec, binaryMessenger: _binaryMessenger);
+        'dev.flutter.pigeon.PdfxApi.openDocumentFile', codec,
+        binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap =
         await channel.send(<Object?>[arg_message]) as Map<Object?, Object?>?;
     if (replyMap == null) {
@@ -567,7 +559,8 @@ class PdfxApi {
         message: 'Unable to establish connection on channel.',
       );
     } else if (replyMap['error'] != null) {
-      final Map<Object?, Object?> error = (replyMap['error'] as Map<Object?, Object?>?)!;
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
       throw PlatformException(
         code: (error['code'] as String?)!,
         message: error['message'] as String?,
@@ -585,7 +578,8 @@ class PdfxApi {
 
   Future<OpenReply> openDocumentAsset(OpenPathMessage arg_message) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.PdfxApi.openDocumentAsset', codec, binaryMessenger: _binaryMessenger);
+        'dev.flutter.pigeon.PdfxApi.openDocumentAsset', codec,
+        binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap =
         await channel.send(<Object?>[arg_message]) as Map<Object?, Object?>?;
     if (replyMap == null) {
@@ -594,7 +588,8 @@ class PdfxApi {
         message: 'Unable to establish connection on channel.',
       );
     } else if (replyMap['error'] != null) {
-      final Map<Object?, Object?> error = (replyMap['error'] as Map<Object?, Object?>?)!;
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
       throw PlatformException(
         code: (error['code'] as String?)!,
         message: error['message'] as String?,
@@ -612,7 +607,8 @@ class PdfxApi {
 
   Future<void> closeDocument(IdMessage arg_message) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.PdfxApi.closeDocument', codec, binaryMessenger: _binaryMessenger);
+        'dev.flutter.pigeon.PdfxApi.closeDocument', codec,
+        binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap =
         await channel.send(<Object?>[arg_message]) as Map<Object?, Object?>?;
     if (replyMap == null) {
@@ -621,7 +617,8 @@ class PdfxApi {
         message: 'Unable to establish connection on channel.',
       );
     } else if (replyMap['error'] != null) {
-      final Map<Object?, Object?> error = (replyMap['error'] as Map<Object?, Object?>?)!;
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
       throw PlatformException(
         code: (error['code'] as String?)!,
         message: error['message'] as String?,
@@ -634,7 +631,8 @@ class PdfxApi {
 
   Future<GetPageReply> getPage(GetPageMessage arg_message) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.PdfxApi.getPage', codec, binaryMessenger: _binaryMessenger);
+        'dev.flutter.pigeon.PdfxApi.getPage', codec,
+        binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap =
         await channel.send(<Object?>[arg_message]) as Map<Object?, Object?>?;
     if (replyMap == null) {
@@ -643,7 +641,8 @@ class PdfxApi {
         message: 'Unable to establish connection on channel.',
       );
     } else if (replyMap['error'] != null) {
-      final Map<Object?, Object?> error = (replyMap['error'] as Map<Object?, Object?>?)!;
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
       throw PlatformException(
         code: (error['code'] as String?)!,
         message: error['message'] as String?,
@@ -661,7 +660,8 @@ class PdfxApi {
 
   Future<RenderPageReply> renderPage(RenderPageMessage arg_message) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.PdfxApi.renderPage', codec, binaryMessenger: _binaryMessenger);
+        'dev.flutter.pigeon.PdfxApi.renderPage', codec,
+        binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap =
         await channel.send(<Object?>[arg_message]) as Map<Object?, Object?>?;
     if (replyMap == null) {
@@ -670,7 +670,8 @@ class PdfxApi {
         message: 'Unable to establish connection on channel.',
       );
     } else if (replyMap['error'] != null) {
-      final Map<Object?, Object?> error = (replyMap['error'] as Map<Object?, Object?>?)!;
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
       throw PlatformException(
         code: (error['code'] as String?)!,
         message: error['message'] as String?,
@@ -688,7 +689,8 @@ class PdfxApi {
 
   Future<void> closePage(IdMessage arg_message) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.PdfxApi.closePage', codec, binaryMessenger: _binaryMessenger);
+        'dev.flutter.pigeon.PdfxApi.closePage', codec,
+        binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap =
         await channel.send(<Object?>[arg_message]) as Map<Object?, Object?>?;
     if (replyMap == null) {
@@ -697,7 +699,8 @@ class PdfxApi {
         message: 'Unable to establish connection on channel.',
       );
     } else if (replyMap['error'] != null) {
-      final Map<Object?, Object?> error = (replyMap['error'] as Map<Object?, Object?>?)!;
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
       throw PlatformException(
         code: (error['code'] as String?)!,
         message: error['message'] as String?,
@@ -710,7 +713,8 @@ class PdfxApi {
 
   Future<RegisterTextureReply> registerTexture() async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.PdfxApi.registerTexture', codec, binaryMessenger: _binaryMessenger);
+        'dev.flutter.pigeon.PdfxApi.registerTexture', codec,
+        binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap =
         await channel.send(null) as Map<Object?, Object?>?;
     if (replyMap == null) {
@@ -719,7 +723,8 @@ class PdfxApi {
         message: 'Unable to establish connection on channel.',
       );
     } else if (replyMap['error'] != null) {
-      final Map<Object?, Object?> error = (replyMap['error'] as Map<Object?, Object?>?)!;
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
       throw PlatformException(
         code: (error['code'] as String?)!,
         message: error['message'] as String?,
@@ -737,7 +742,8 @@ class PdfxApi {
 
   Future<void> updateTexture(UpdateTextureMessage arg_message) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.PdfxApi.updateTexture', codec, binaryMessenger: _binaryMessenger);
+        'dev.flutter.pigeon.PdfxApi.updateTexture', codec,
+        binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap =
         await channel.send(<Object?>[arg_message]) as Map<Object?, Object?>?;
     if (replyMap == null) {
@@ -746,7 +752,8 @@ class PdfxApi {
         message: 'Unable to establish connection on channel.',
       );
     } else if (replyMap['error'] != null) {
-      final Map<Object?, Object?> error = (replyMap['error'] as Map<Object?, Object?>?)!;
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
       throw PlatformException(
         code: (error['code'] as String?)!,
         message: error['message'] as String?,
@@ -759,7 +766,8 @@ class PdfxApi {
 
   Future<void> resizeTexture(ResizeTextureMessage arg_message) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.PdfxApi.resizeTexture', codec, binaryMessenger: _binaryMessenger);
+        'dev.flutter.pigeon.PdfxApi.resizeTexture', codec,
+        binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap =
         await channel.send(<Object?>[arg_message]) as Map<Object?, Object?>?;
     if (replyMap == null) {
@@ -768,7 +776,8 @@ class PdfxApi {
         message: 'Unable to establish connection on channel.',
       );
     } else if (replyMap['error'] != null) {
-      final Map<Object?, Object?> error = (replyMap['error'] as Map<Object?, Object?>?)!;
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
       throw PlatformException(
         code: (error['code'] as String?)!,
         message: error['message'] as String?,
@@ -781,7 +790,8 @@ class PdfxApi {
 
   Future<void> unregisterTexture(UnregisterTextureMessage arg_message) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.PdfxApi.unregisterTexture', codec, binaryMessenger: _binaryMessenger);
+        'dev.flutter.pigeon.PdfxApi.unregisterTexture', codec,
+        binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap =
         await channel.send(<Object?>[arg_message]) as Map<Object?, Object?>?;
     if (replyMap == null) {
@@ -790,7 +800,8 @@ class PdfxApi {
         message: 'Unable to establish connection on channel.',
       );
     } else if (replyMap['error'] != null) {
-      final Map<Object?, Object?> error = (replyMap['error'] as Map<Object?, Object?>?)!;
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
       throw PlatformException(
         code: (error['code'] as String?)!,
         message: error['message'] as String?,

--- a/packages/pdfx/lib/src/renderer/io/platform_pigeon.dart
+++ b/packages/pdfx/lib/src/renderer/io/platform_pigeon.dart
@@ -62,7 +62,7 @@ class PdfDocumentPigeon extends PdfDocument {
     required super.sourceName,
     required super.id,
     required super.pagesCount,
-  })  : _pages = List<PdfPage?>.filled(pagesCount, null);
+  }) : _pages = List<PdfPage?>.filled(pagesCount, null);
 
   final List<PdfPage?> _pages;
 

--- a/packages/pdfx/lib/src/renderer/web/constants.dart
+++ b/packages/pdfx/lib/src/renderer/web/constants.dart
@@ -1,7 +1,8 @@
 import 'package:pdfx/src/renderer/web/pdfjs.dart';
 
 class Constants {
-  static PdfjsRenderOptions defaultPdfjsRenderOptions = PdfjsRenderOptions.constant(
+  static PdfjsRenderOptions defaultPdfjsRenderOptions =
+      PdfjsRenderOptions.constant(
     cMapUrl: 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/cmaps/',
     cMapPacked: true,
   );


### PR DESCRIPTION
## Summary
- Add a test workflow that detects which of the 5 packages changed and only runs `dart format`, `flutter analyze --fatal-infos` and `flutter test` for those, to save CI minutes
- Add a publish workflow triggered by a per package tag (`<package>-v<version>`) or manually from the Actions UI, which auto detects packages whose pubspec version is newer than what is published on pub.dev and publishes them using trusted OIDC publishing (no stored credentials)
- Add Dependabot config for the pub packages and the GitHub Actions used in the workflows
- Apply `dart format` to a few files in epub_view and pdfx that were not compliant, since the new format check would otherwise fail immediately

## Test plan
- [ ] Confirm the test workflow only runs for the package(s) touched in this PR
- [ ] Configure pub.dev Automated Publishing for the remaining packages (explorer, flutter_color, pdfx) with `Tag pattern = <package>-v{{version}}` and workflow_dispatch enabled
- [ ] Trigger the publish workflow once manually (workflow_dispatch) after merge to confirm it correctly reports "up to date" for all packages
- [ ] Push a test tag for one package to confirm the tag driven publish path works end to end