### PR TITLE
Skip test step for packages without a test directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,5 +48,11 @@ jobs:
         working-directory: packages/${{ matrix.package }}
       - run: flutter analyze --fatal-infos
         working-directory: packages/${{ matrix.package }}
-      - run: flutter test
+      - name: Run tests
         working-directory: packages/${{ matrix.package }}
+        run: |
+          if [ -d test ]; then
+            flutter test
+          else
+            echo "No test directory, skipping."
+          fi


### PR DESCRIPTION
## Summary
- `flutter test` fails hard with "Test directory not found" for packages like auto_animated that have no `test/` folder, which currently blocks CI on their Dependabot PRs even though there is nothing to test
- Guard the test step so it only runs `flutter test` when a `test/` directory exists, otherwise it logs and continues

## Test plan
- [ ] Confirm the auto_animated Dependabot PR (#639) turns green after this merges and its check is re-run