### PR TITLE
Release epub_view 3.3.0, explorer 2.3.1, flutter_color 2.1.1, pdfx 2.10.0

### DIFF
--- a/packages/epub_view/CHANGELOG.md
+++ b/packages/epub_view/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 3.3.0
 
 * Added support for opening books from a URL via `EpubDocument.openUrl` [pull#470](https://github.com/ScerIO/packages.flutter/pull/470)
 

--- a/packages/epub_view/pubspec.yaml
+++ b/packages/epub_view/pubspec.yaml
@@ -2,7 +2,7 @@ name: epub_view
 description: Flutter widget for view EPUB documents on on Web, MacOs, Android and iOS. Based on dart-epub package.
 repository: https://github.com/ScerIO/packages.flutter/tree/main/packages/epub_view
 issue_tracker: https://github.com/ScerIO/packages.flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+epub_view%22
-version: 3.2.0
+version: 3.3.0
 
 environment:
   sdk: ">=2.17.1 <4.0.0"

--- a/packages/explorer/CHANGELOG.md
+++ b/packages/explorer/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 2.3.1
 
 * Fixed `intl` constraint that could block `pub get` on newer Flutter SDKs [pull#627](https://github.com/ScerIO/packages.flutter/pull/627)
 

--- a/packages/explorer/pubspec.yaml
+++ b/packages/explorer/pubspec.yaml
@@ -2,7 +2,7 @@ name: explorer
 description: 'Universal explorer UI for navigate files, ftp, etc. Support custom providers and any platforms c:'
 repository: https://github.com/ScerIO/packages.flutter/tree/main/packages/explorer
 issue_tracker: https://github.com/ScerIO/packages.flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+explorer%22
-version: 2.3.0
+version: 2.3.1
 
 environment:
   sdk: '>=2.12.0 <4.0.0'

--- a/packages/flutter_color/CHANGELOG.md
+++ b/packages/flutter_color/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 2.1.1
 
 * Replaced deprecated `Color.red`/`green`/`blue`/`alpha`/`value` accessors with the float-based API [pull#629](https://github.com/ScerIO/packages.flutter/pull/629)
 

--- a/packages/flutter_color/pubspec.yaml
+++ b/packages/flutter_color/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_color
 description: Flutter plugin for works with colors schemes like a hex, hsl, xyz and cielab
 repository: https://github.com/ScerIO/packages.flutter/tree/main/packages/flutter_color
 issue_tracker: https://github.com/ScerIO/packages.flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_color%22
-version: 2.1.0
+version: 2.1.1
 
 environment:
   sdk: '>=2.12.0 <4.0.0'

--- a/packages/pdfx/CHANGELOG.md
+++ b/packages/pdfx/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 2.10.0
 
 * Supported AGP 9 built-in Kotlin [pull#624](https://github.com/ScerIO/packages.flutter/pull/624)
 * Supported Windows ARM64 build [pull#620](https://github.com/ScerIO/packages.flutter/pull/620)

--- a/packages/pdfx/pubspec.yaml
+++ b/packages/pdfx/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdfx
 description: Flutter plugin to render & show PDF pages as images on Web, MacOS, Windows, Android and iOS.
 repository: https://github.com/ScerIO/packages.flutter/tree/main/packages/pdfx
 issue_tracker: https://github.com/ScerIO/packages.flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pdfx%22
-version: 2.9.2
+version: 2.10.0
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
## Summary
- Bump version and release the pending `NEXT` changelog entries for 4 packages:
  - epub_view 3.2.0 -> 3.3.0 (new `EpubDocument.openUrl` support)
  - explorer 2.3.0 -> 2.3.1 (intl constraint fix)
  - flutter_color 2.1.0 -> 2.1.1 (replaced deprecated Color accessors)
  - pdfx 2.9.2 -> 2.10.0 (Windows ARM64 support, AGP 9, new exposed callbacks, various fixes)
- auto_animated is intentionally left out, it has no pending changelog entries
- This is also the first real end to end test of the new publish workflow: after merge we'll trigger it manually to publish all 4 to pub.dev

## Test plan
- [x] Merge this PR
- [x] Run the `Publish` workflow manually from the Actions tab
- [x] Confirm all 4 packages are detected and published, and that pub.dev shows the new versions