### PR TITLE
Raise pdfx minimum Flutter version to 3.29.0

### DIFF
--- a/packages/pdfx/CHANGELOG.md
+++ b/packages/pdfx/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## NEXT
 
 * Added Swift Package Manager support for iOS and macOS, consolidating the duplicated Apple implementation into shared Darwin sources while retaining CocoaPods compatibility [pull#623](https://github.com/ScerIO/packages.flutter/pull/623)
+* Fixed a NaN/Infinity crash in `PdfViewPinch` document progress when the document exactly fits the viewport [pull#621](https://github.com/ScerIO/packages.flutter/pull/621)
+* Raised the minimum Flutter version to 3.29.0, since the current `onSurfaceAvailable`/`onSurfaceCleanup` `SurfaceProducer.Callback` overrides do not exist on older engines and failed to compile on Flutter 3.24-3.28 [issue#580](https://github.com/ScerIO/packages.flutter/issues/580)
 
 ## 2.10.0
 

--- a/packages/pdfx/pubspec.yaml
+++ b/packages/pdfx/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.10.0
 
 environment:
   sdk: '>=3.3.0 <4.0.0'
-  flutter: '>=3.24.0'
+  flutter: '>=3.29.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- Raises pdfx's minimum Flutter version from 3.24.0 to 3.29.0
- The current `SurfaceProducer.Callback` overrides use `onSurfaceAvailable` (added in Flutter 3.27) and `onSurfaceCleanup` (added in Flutter 3.29), so the plugin cannot actually compile against the 3.24.0 minimum it claimed, matching the "overrides nothing" compile errors reported in #580
- Closes #583 in favor of this fix: that PR only reverted `onSurfaceCleanup` back to the deprecated `onSurfaceDestroyed` alias, which would still leave `onSurfaceAvailable` broken on Flutter 3.24-3.26 and reintroduce a deprecated, `forRemoval=true` API call on newer engines
- Backfills the CHANGELOG entry for the NaN/Infinity progress fix from #621, which was merged without one

## Test plan
- [x] `dart format`, `flutter analyze --fatal-infos`, `flutter test` all pass locally