### PR TITLE
Release pdfx 2.11.0

### DIFF
--- a/packages/pdfx/CHANGELOG.md
+++ b/packages/pdfx/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 2.11.0
 
 * Added Swift Package Manager support for iOS and macOS, consolidating the duplicated Apple implementation into shared Darwin sources while retaining CocoaPods compatibility [pull#623](https://github.com/ScerIO/packages.flutter/pull/623)
 * Fixed a NaN/Infinity crash in `PdfViewPinch` document progress when the document exactly fits the viewport [pull#621](https://github.com/ScerIO/packages.flutter/pull/621)

--- a/packages/pdfx/pubspec.yaml
+++ b/packages/pdfx/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdfx
 description: Flutter plugin to render & show PDF pages as images on Web, MacOS, Windows, Android and iOS.
 repository: https://github.com/ScerIO/packages.flutter/tree/main/packages/pdfx
 issue_tracker: https://github.com/ScerIO/packages.flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pdfx%22
-version: 2.10.0
+version: 2.11.0
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
## Summary
- Bumps pdfx to 2.11.0 and closes the NEXT changelog section
- Includes: Swift Package Manager support (#623), the PdfViewPinch NaN/Infinity progress fix (#621), and the raised Flutter 3.29.0 minimum (#645)

## Test plan
- [x] `dart format`, `flutter analyze --fatal-infos`, `flutter test` all pass locally
- [ ] Publish to pub.dev after merge